### PR TITLE
Add contributors section to README | Solving #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,4 +238,13 @@ The application uses the following default configuration:
 
 ## License
 
-You can see the [lisence](https://github.com/Deadlink-Hunter/Broken-Link-Checker/blob/main/LICENSE) file
+
+You can see the [licence](https://github.com/Deadlink-Hunter/Broken-Link-Checker/blob/main/LICENSE) file
+
+## Contributors
+
+Thanks to all the amazing contributors:
+
+<a href="https://github.com/Deadlink-Hunter/Broken-Link-Checker/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Deadlink-Hunter/Broken-Link-Checker" alt="Contributors" />
+</a>


### PR DESCRIPTION
Added a new 'Contributors' section to the README with a badge displaying project contributors. Also fixed a typo in the word 'license'.