### PR TITLE
fix: add .prettierrc with endOfLine auto to resolve CRLF eslint errors

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{"endOfLine":"auto","singleQuote":true,"semi":true,"tabWidth":2,"trailingComma":"es5"}


### PR DESCRIPTION
## Problem

On Windows machines, ESLint reports `Delete '␍'` errors because Prettier's default `endOfLine` is `lf`, but Windows git checkouts produce CRLF line endings.

## Fix

Add a `.prettierrc` config file with `"endOfLine": "auto"` so Prettier accepts the platform-native line ending, eliminating the CRLF lint errors on Windows without forcing LF on all contributors.

Additional sensible defaults included (`singleQuote`, `semi`, `tabWidth`, `trailingComma`) to match the TypeScript conventions already in use.

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to standardize development environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->