### PR TITLE
feat: add soft 404 detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.3",
     "husky": "^9.1.7",
+    "msw": "^2.13.4",
     "prettier": "^3.6.2",
     "supertest": "^7.1.4",
     "tsc-alias": "^1.8.16",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ export const HTTP_STATUS_INTERNAL_SERVER_ERROR = 500;
 
 export const INVALID_URL_FORMAT = "Invalid URL format";
 export const FAILED_REQUEST = "Request failed";
+export const SOFT_404_DETECTED = "Page returned 404 content despite 200 status";
 export const URLS_ARRAY_REQUIRED = "URLs array is required";
 export const URL_WORKING = "URL check completed - URL is working";
 export const URL_BROKEN = "URL check completed - URL is broken";

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,3 @@
+import { setupServer } from "msw/node";
+
+export const server = setupServer();

--- a/src/services/urlService.soft404.test.ts
+++ b/src/services/urlService.soft404.test.ts
@@ -1,14 +1,8 @@
-import { beforeAll, afterEach, afterAll, describe, it, expect } from "vitest";
-import { setupServer } from "msw/node";
+import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { checkUrl } from "@urlService";
 import { SOFT_404_DETECTED } from "@constant";
-
-const server = setupServer();
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+import { server } from "@/mocks/server";
 
 const MOCK_URL = "https://mock-soft-404.com";
 

--- a/src/services/urlService.soft404.test.ts
+++ b/src/services/urlService.soft404.test.ts
@@ -1,0 +1,95 @@
+import { beforeAll, afterEach, afterAll, describe, it, expect } from "vitest";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { checkUrl } from "@urlService";
+import { SOFT_404_DETECTED } from "@constant";
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const MOCK_URL = "https://mock-soft-404.com";
+
+describe("soft 404 detection", () => {
+  it("should return isBroken: true when title contains '404'", async () => {
+    server.use(
+      http.get(MOCK_URL, () =>
+        HttpResponse.html(
+          "<html><head><title>404 Not Found</title></head><body>oops</body></html>",
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.error).toBe(SOFT_404_DETECTED);
+  });
+
+  it("should return isBroken: true when title contains 'not found'", async () => {
+    server.use(
+      http.get(MOCK_URL, () =>
+        HttpResponse.html(
+          "<html><head><title>Page Not Found</title></head><body>oops</body></html>",
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(true);
+    expect(result.error).toBe(SOFT_404_DETECTED);
+  });
+
+  it("should return isBroken: false when title is normal", async () => {
+    server.use(
+      http.get(MOCK_URL, () =>
+        HttpResponse.html(
+          "<html><head><title>Welcome to our site</title></head><body>hello</body></html>",
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(false);
+    expect(result.statusCode).toBe(200);
+  });
+
+  it("should return isBroken: false when response is JSON (non-HTML)", async () => {
+    server.use(
+      http.get(MOCK_URL, () =>
+        HttpResponse.json({ message: "not found", code: 404 }, { status: 200 }),
+      ),
+    );
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(false);
+    expect(result.statusCode).toBe(200);
+  });
+
+  it("should return isBroken: false when body is empty", async () => {
+    server.use(
+      http.get(
+        MOCK_URL,
+        () =>
+          new HttpResponse("", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+          }),
+      ),
+    );
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(false);
+    expect(result.statusCode).toBe(200);
+  });
+});

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -27,9 +27,9 @@ const isValidUrl = (url: string): boolean => {
 const isSoft404 = (response: AxiosResponse): boolean => {
   const contentType = response.headers["content-type"] || "";
   if (!contentType.includes("text/html")) return false;
-  if (!response.data.trim()) return false;
 
   const body: string = response.data;
+  if (typeof body !== "string" || !body.trim()) return false;
   const titleMatch = body.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
   const title = titleMatch?.[1]?.toLowerCase() ?? "";
 

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -4,6 +4,7 @@ import {
   HTTP_TIMEOUT,
   INVALID_URL_FORMAT,
   MAX_REDIRECTS,
+  SOFT_404_DETECTED,
 } from "@constant";
 
 export interface UrlCheckResult {
@@ -21,6 +22,24 @@ const isValidUrl = (url: string): boolean => {
   } catch {
     return false;
   }
+};
+
+const isSoft404 = (response: AxiosResponse): boolean => {
+  const contentType = response.headers["content-type"] || "";
+  if (!contentType.includes("text/html")) return false;
+  if (!response.data.trim()) return false;
+
+  const body: string = response.data;
+  const titleMatch = body.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch?.[1]?.toLowerCase() ?? "";
+
+  const finalUrl = response.request?.res?.responseUrl ?? "";
+
+  return (
+    title.includes("404") ||
+    title.includes("not found") ||
+    finalUrl.includes("/404")
+  );
 };
 
 export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
@@ -49,6 +68,16 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
     });
 
     const responseTime = Date.now() - startTime;
+
+    if (isSoft404(response)) {
+      return {
+        url,
+        isBroken: true,
+        statusCode: response.status,
+        error: SOFT_404_DETECTED,
+        responseTime,
+      };
+    }
 
     return {
       url,

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -6,6 +6,7 @@ import {
   MAX_REDIRECTS,
   SOFT_404_DETECTED,
 } from "@constant";
+import { HTML_TITLE_REGEX } from "@/utils/regexUtils";
 
 export interface UrlCheckResult {
   url: string;
@@ -30,7 +31,7 @@ const isSoft404 = (response: AxiosResponse): boolean => {
 
   const body: string = response.data;
   if (typeof body !== "string" || !body.trim()) return false;
-  const titleMatch = body.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const titleMatch = body.match(HTML_TITLE_REGEX);
   const title = titleMatch?.[1]?.toLowerCase() ?? "";
 
   const finalUrl = response.request?.res?.responseUrl ?? "";

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,6 @@
+import { beforeAll, afterEach, afterAll } from "vitest";
+import { server } from "@/mocks/server";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/src/utils/regexUtils.ts
+++ b/src/utils/regexUtils.ts
@@ -1,0 +1,1 @@
+export const HTML_TITLE_REGEX = /<title[^>]*>([\s\S]*?)<\/title>/i;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,5 +2,9 @@ import { defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [tsconfigPaths()], 
+  plugins: [tsconfigPaths()],
+  test: {
+    setupFiles: ['./src/tests/setup.ts'],
+    exclude: ['dist/**', 'node_modules/**'],
+  },
 });


### PR DESCRIPTION
## Description
Some URLs return HTTP 200 but display a 404 page internally, for example, sites that redirect broken links to their homepage with a 200 status. The existing checker marked these as working since it only validated the HTTP status code. Added a isSoft404 helper in urlService.ts that inspects the HTML <title> tag and final redirect URL to detect and flag these cases as broken.

No new tests were added, reliably testing soft 404 detection requires a real URL that consistently returns a soft 404, which would make the test flaky and environment-dependent. All existing tests pass.

## Related Issue(s)
Fixes #26

## Checklist:
- [x]  I have performed a self-review of my own code
- [ ]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation to detect and flag soft-404 pages (pages that show 404-like content despite a 200 status), preserving original status codes and response times.
* **Tests**
  * Added automated tests covering soft-404 scenarios (titles containing "404" or "not found", non-HTML responses, empty bodies) and test lifecycle setup.
* **Chores**
  * Added a lightweight mock-server dev tool and test setup configuration to support the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->