### PR TITLE
feat: handle localhost urls and modify message field in url data (#24)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,6 +22,12 @@ export const INTERNAL_SERVER_ERROR = "Internal server error";
 export const HEALTH_CHECK_MESSAGE = "URL Checker API is running";
 export const URL_CHECK_COMPLETED = (working: number, broken: number) =>
   `URL check completed - ${working} working, ${broken} broken`;
+export const LOCALHOST_URLS = new Set<string>([
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+  "::1",
+]);
 
 export const TEST_ENV = "test";
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,12 +22,7 @@ export const INTERNAL_SERVER_ERROR = "Internal server error";
 export const HEALTH_CHECK_MESSAGE = "URL Checker API is running";
 export const URL_CHECK_COMPLETED = (working: number, broken: number) =>
   `URL check completed - ${working} working, ${broken} broken`;
-export const LOCALHOST_URLS = new Set<string>([
-  "localhost",
-  "127.0.0.1",
-  "[::1]",
-  "::1",
-]);
+export const LOCALHOST_URLS = ["localhost", "127.0.0.1", "[::1]", "::1"];
 
 export const TEST_ENV = "test";
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,6 +15,8 @@ export const URL_WORKING = "URL check completed - URL is working";
 export const URL_BROKEN = "URL check completed - URL is broken";
 export const ONE_URL_REQUIRED = "At least one URL is required";
 export const URL_REQUIRED = "URL is required";
+export const LOCALHOST_URL_MESSAGE =
+  "URL is not considered broken as it runs on localhost";
 export const MAXIMUM_URLS_ALLOWED = `Maximum ${MAX_URLS_PER_REQUEST} URLs allowed per request`;
 export const INTERNAL_SERVER_ERROR = "Internal server error";
 export const HEALTH_CHECK_MESSAGE = "URL Checker API is running";

--- a/src/controllers/url/urlController.ts
+++ b/src/controllers/url/urlController.ts
@@ -6,8 +6,6 @@ import {
   HTTP_STATUS_BAD_REQUEST,
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
   URL_REQUIRED,
-  URL_BROKEN,
-  URL_WORKING,
   INTERNAL_SERVER_ERROR,
   URLS_ARRAY_REQUIRED,
   ONE_URL_REQUIRED,
@@ -38,7 +36,6 @@ export const checkSingleUrl = async (
     res.status(200).json({
       success: true,
       data: result,
-      message: result.isBroken ? URL_BROKEN : URL_WORKING,
     });
   } catch (error: any) {
     res.status(HTTP_STATUS_INTERNAL_SERVER_ERROR).json({

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -8,6 +8,7 @@ import {
   LOCALHOST_URL_MESSAGE,
   URL_WORKING,
   URL_BROKEN,
+  LOCALHOST_URLS,
 } from "@constant";
 import { HTML_TITLE_REGEX } from "@/utils/regexUtils";
 
@@ -30,12 +31,12 @@ const isValidUrl = (url: string): boolean => {
 };
 
 const isLocalhostUrl = (url: string): boolean => {
-  const { hostname } = new URL(url);
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "::1"
-  );
+  try {
+    const { hostname } = new URL(url);
+    return LOCALHOST_URLS.has(hostname);
+  } catch {
+    return false;
+  }
 };
 
 const isSoft404 = (response: AxiosResponse): boolean => {

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -5,6 +5,9 @@ import {
   INVALID_URL_FORMAT,
   MAX_REDIRECTS,
   SOFT_404_DETECTED,
+  LOCALHOST_URL_MESSAGE,
+  URL_WORKING,
+  URL_BROKEN,
 } from "@constant";
 import { HTML_TITLE_REGEX } from "@/utils/regexUtils";
 
@@ -14,6 +17,7 @@ export interface UrlCheckResult {
   statusCode?: number;
   error?: string;
   responseTime?: number;
+  message?: string;
 }
 
 const isValidUrl = (url: string): boolean => {
@@ -23,6 +27,11 @@ const isValidUrl = (url: string): boolean => {
   } catch {
     return false;
   }
+};
+
+const isLocalhostUrl = (url: string): boolean => {
+  const { hostname } = new URL(url);
+  return hostname === "localhost" || hostname === "127.0.0.1";
 };
 
 const isSoft404 = (response: AxiosResponse): boolean => {
@@ -52,6 +61,15 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
         url,
         isBroken: true,
         error: INVALID_URL_FORMAT,
+        message: URL_BROKEN,
+      };
+    }
+
+    if (isLocalhostUrl(url)) {
+      return {
+        url,
+        isBroken: false,
+        message: LOCALHOST_URL_MESSAGE,
       };
     }
 
@@ -77,6 +95,7 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
         statusCode: response.status,
         error: SOFT_404_DETECTED,
         responseTime,
+        message: URL_BROKEN,
       };
     }
 
@@ -85,6 +104,7 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
       isBroken: false,
       statusCode: response.status,
       responseTime,
+      message: URL_WORKING,
     };
   } catch (error: any) {
     const responseTime = Date.now() - startTime;
@@ -95,6 +115,7 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
       statusCode: error.response?.status,
       error: error.message || FAILED_REQUEST,
       responseTime,
+      message: URL_BROKEN,
     };
   }
 };

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -33,7 +33,7 @@ const isValidUrl = (url: string): boolean => {
 const isLocalhostUrl = (url: string): boolean => {
   try {
     const { hostname } = new URL(url);
-    return LOCALHOST_URLS.has(hostname);
+    return LOCALHOST_URLS.includes(hostname);
   } catch {
     return false;
   }

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -31,7 +31,11 @@ const isValidUrl = (url: string): boolean => {
 
 const isLocalhostUrl = (url: string): boolean => {
   const { hostname } = new URL(url);
-  return hostname === "localhost" || hostname === "127.0.0.1";
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1"
+  );
 };
 
 const isSoft404 = (response: AxiosResponse): boolean => {


### PR DESCRIPTION
Fixes #24 

Changes made:

- `isLocalhostUrl` check in `urlService.ts` for `localhost` and `127.0.0.1`. These URLs now return isBroken: false with a localhost message `URL is not considered broken as it runs on localhost`. `const LOCALHOST_URL_MESSAGE` is defined in `src/constants/index.ts`
- Added message field to `interface UrlCheckResult`. Now response includes a message inside `data` for single URLs and inside `results` array for multiple URLs
- Removed top level message from single URL

Single URL response:
```json
{
  "success": true,
  "data": {
    "url": "http://localhost:3000/abc/123",
    "isBroken": false,
    "message": "URL is not considered broken as it runs on localhost"
  }
}
```

Multiple URLs response:
```json
{
  "success": true,
  "data": {
    "results": [
      {
        "url": "https://example.com",
        "isBroken": false,
        "statusCode": 200,
        "responseTime": 154,
        "message": "URL check completed - URL is working"
      },
      {
        "url": "some-broken-url",
        "isBroken": true,
        "error": "getaddrinfo ENOTFOUND sdf",
        "responseTime": 2923,
        "message": "URL check completed - URL is broken"
      },
      {
        "url": "http://localhost:3000/abc/123",
        "isBroken": false,
        "message": "URL is not considered broken as it runs on localhost"
      }
    ],
    "summary": {
      "total": 3,
      "broken": 1,
      "working": 2
    }
  },
  "message": "URL check completed - 2 working, 1 broken"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL checks now include explicit, descriptive status messages with results.
  * Localhost and loopback addresses are recognized and no longer reported as broken, improving local testing feedback.
* **Bug Fixes**
  * Soft-404s and invalid URLs consistently return a "broken" status message for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->