### PR TITLE
Feature/add retry logic for server errors

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -29,3 +29,6 @@ export const TEST_ENV = "test";
 export const URL_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 export const URL_RATE_LIMIT_MAX_REQUESTS = 30;
 export const RATE_LIMIT_MESSAGE = "Too many requests, please try again later.";
+
+export const MAX_RETRY_ATTEMPTS = 3;
+export const RETRY_DELAY_MS = 1000;

--- a/src/services/urlService.retry.test.ts
+++ b/src/services/urlService.retry.test.ts
@@ -4,7 +4,6 @@ import { checkUrl } from "@urlService";
 import { SOFT_404_DETECTED, MAX_RETRY_ATTEMPTS } from "@constant";
 import { server } from "@/mocks/server";
 
-// Mock delay to avoid waiting during retry tests
 vi.mock("timers/promises", () => ({
   setTimeout: vi.fn().mockResolvedValue(undefined),
 }));
@@ -16,66 +15,76 @@ const OK_HTML = "<html><head><title>Home</title></head><body>ok</body></html>";
 const SOFT_404_HTML =
   "<html><head><title>404 Not Found</title></head><body>oops</body></html>";
 
-function mockGet(handler: () => any) {
-  server.use(http.get(MOCK_URL, handler));
-}
-
 describe("checkUrl retry logic", () => {
   it("succeeds on the first attempt and sets attempts to 1", async () => {
-    mockGet(() => HttpResponse.html(OK_HTML, { status: 200 }));
+    server.use(http.get(MOCK_URL, () => HttpResponse.html(OK_HTML, { status: 200 })));
 
     const result = await checkUrl(MOCK_URL);
 
-    expect(result.isBroken).toBe(false);
-    expect(result.statusCode).toBe(200);
-    expect(result.attempts).toBe(1);
+    expect(result).toMatchObject({
+      isBroken: false,
+      statusCode: 200,
+      attempts: 1,
+    });
   });
 
   it("retries after a 5xx error and succeeds on the second attempt", async () => {
     let callCount = 0;
 
-    mockGet(() => {
-      callCount += 1;
-      if (callCount === 1) {
-        return HttpResponse.json({}, { status: 500 });
-      }
-      return HttpResponse.html(OK_HTML, { status: 200 });
-    });
+    server.use(
+      http.get(MOCK_URL, () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return HttpResponse.json({}, { status: 500 });
+        }
+        return HttpResponse.html(OK_HTML, { status: 200 });
+      })
+    );
 
     const result = await checkUrl(MOCK_URL);
 
-    expect(result.isBroken).toBe(false);
-    expect(result.statusCode).toBe(200);
-    expect(result.attempts).toBe(2);
+    expect(result).toMatchObject({
+      isBroken: false,
+      statusCode: 200,
+      attempts: 2,
+    });
   });
 
   it("returns broken after exhausting all retry attempts on a persistent 5xx error", async () => {
-    mockGet(() => HttpResponse.json({}, { status: 500 }));
+    server.use(http.get(MOCK_URL, () => HttpResponse.json({}, { status: 500 })));
 
     const result = await checkUrl(MOCK_URL);
 
-    expect(result.isBroken).toBe(true);
-    expect(result.statusCode).toBe(500);
-    expect(result.attempts).toBe(MAX_RETRY_ATTEMPTS);
+    expect(result).toMatchObject({
+      isBroken: true,
+      statusCode: 500,
+      attempts: MAX_RETRY_ATTEMPTS,
+    });
   });
 
   it("does not retry a 4xx error and returns broken with attempts: 1", async () => {
-    mockGet(() => HttpResponse.json({}, { status: 404 }));
+    server.use(http.get(MOCK_URL, () => HttpResponse.json({}, { status: 404 })));
 
     const result = await checkUrl(MOCK_URL);
 
-    expect(result.isBroken).toBe(true);
-    expect(result.statusCode).toBe(404);
-    expect(result.attempts).toBe(1);
+    expect(result).toMatchObject({
+      isBroken: true,
+      statusCode: 404,
+      attempts: 1,
+    });
   });
 
   it("does not retry a soft-404 and returns broken with attempts: 1", async () => {
-    mockGet(() => HttpResponse.html(SOFT_404_HTML, { status: 200 }));
+    server.use(
+      http.get(MOCK_URL, () => HttpResponse.html(SOFT_404_HTML, { status: 200 }))
+    );
 
     const result = await checkUrl(MOCK_URL);
 
-    expect(result.isBroken).toBe(true);
-    expect(result.error).toBe(SOFT_404_DETECTED);
-    expect(result.attempts).toBe(1);
+    expect(result).toMatchObject({
+      isBroken: true,
+      error: SOFT_404_DETECTED,
+      attempts: 1,
+    });
   });
 });

--- a/src/services/urlService.retry.test.ts
+++ b/src/services/urlService.retry.test.ts
@@ -17,7 +17,9 @@ const SOFT_404_HTML =
 
 describe("checkUrl retry logic", () => {
   it("succeeds on the first attempt and sets attempts to 1", async () => {
-    server.use(http.get(MOCK_URL, () => HttpResponse.html(OK_HTML, { status: 200 })));
+    server.use(
+      http.get(MOCK_URL, () => HttpResponse.html(OK_HTML, { status: 200 })),
+    );
 
     const result = await checkUrl(MOCK_URL);
 
@@ -38,7 +40,7 @@ describe("checkUrl retry logic", () => {
           return HttpResponse.json({}, { status: 500 });
         }
         return HttpResponse.html(OK_HTML, { status: 200 });
-      })
+      }),
     );
 
     const result = await checkUrl(MOCK_URL);
@@ -51,7 +53,9 @@ describe("checkUrl retry logic", () => {
   });
 
   it("returns broken after exhausting all retry attempts on a persistent 5xx error", async () => {
-    server.use(http.get(MOCK_URL, () => HttpResponse.json({}, { status: 500 })));
+    server.use(
+      http.get(MOCK_URL, () => HttpResponse.json({}, { status: 500 })),
+    );
 
     const result = await checkUrl(MOCK_URL);
 
@@ -63,7 +67,9 @@ describe("checkUrl retry logic", () => {
   });
 
   it("does not retry a 4xx error and returns broken with attempts: 1", async () => {
-    server.use(http.get(MOCK_URL, () => HttpResponse.json({}, { status: 404 })));
+    server.use(
+      http.get(MOCK_URL, () => HttpResponse.json({}, { status: 404 })),
+    );
 
     const result = await checkUrl(MOCK_URL);
 
@@ -76,7 +82,9 @@ describe("checkUrl retry logic", () => {
 
   it("does not retry a soft-404 and returns broken with attempts: 1", async () => {
     server.use(
-      http.get(MOCK_URL, () => HttpResponse.html(SOFT_404_HTML, { status: 200 }))
+      http.get(MOCK_URL, () =>
+        HttpResponse.html(SOFT_404_HTML, { status: 200 }),
+      ),
     );
 
     const result = await checkUrl(MOCK_URL);

--- a/src/services/urlService.retry.test.ts
+++ b/src/services/urlService.retry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { checkUrl } from "@urlService";
+import { SOFT_404_DETECTED, MAX_RETRY_ATTEMPTS } from "@constant";
+import { server } from "@/mocks/server";
+
+// Mock delay to avoid waiting during retry tests
+vi.mock("timers/promises", () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
+const MOCK_URL = "https://mock-retry.com";
+
+const OK_HTML = "<html><head><title>Home</title></head><body>ok</body></html>";
+
+const SOFT_404_HTML =
+  "<html><head><title>404 Not Found</title></head><body>oops</body></html>";
+
+function mockGet(handler: () => any) {
+  server.use(http.get(MOCK_URL, handler));
+}
+
+describe("checkUrl retry logic", () => {
+  it("succeeds on the first attempt and sets attempts to 1", async () => {
+    mockGet(() => HttpResponse.html(OK_HTML, { status: 200 }));
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(false);
+    expect(result.statusCode).toBe(200);
+    expect(result.attempts).toBe(1);
+  });
+
+  it("retries after a 5xx error and succeeds on the second attempt", async () => {
+    let callCount = 0;
+
+    mockGet(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return HttpResponse.json({}, { status: 500 });
+      }
+      return HttpResponse.html(OK_HTML, { status: 200 });
+    });
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(false);
+    expect(result.statusCode).toBe(200);
+    expect(result.attempts).toBe(2);
+  });
+
+  it("returns broken after exhausting all retry attempts on a persistent 5xx error", async () => {
+    mockGet(() => HttpResponse.json({}, { status: 500 }));
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(true);
+    expect(result.statusCode).toBe(500);
+    expect(result.attempts).toBe(MAX_RETRY_ATTEMPTS);
+  });
+
+  it("does not retry a 4xx error and returns broken with attempts: 1", async () => {
+    mockGet(() => HttpResponse.json({}, { status: 404 }));
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(true);
+    expect(result.statusCode).toBe(404);
+    expect(result.attempts).toBe(1);
+  });
+
+  it("does not retry a soft-404 and returns broken with attempts: 1", async () => {
+    mockGet(() => HttpResponse.html(SOFT_404_HTML, { status: 200 }));
+
+    const result = await checkUrl(MOCK_URL);
+
+    expect(result.isBroken).toBe(true);
+    expect(result.error).toBe(SOFT_404_DETECTED);
+    expect(result.attempts).toBe(1);
+  });
+});

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -163,6 +163,7 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
   };
 };
 
+// TODO: Re-test this flow once repository link scanning is implemented.
 export const checkMultipleUrls = async (
   urls: string[],
 ): Promise<UrlCheckResult[]> => {

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -143,9 +143,9 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
       return { ...result, attempts: attempt };
     }
 
+    const status = result.statusCode;
     const isNonRetryable =
-      result.statusCode &&
-      result.statusCode < HTTP_STATUS_INTERNAL_SERVER_ERROR;
+      typeof status === "number" && status < HTTP_STATUS_INTERNAL_SERVER_ERROR;
 
     if (isNonRetryable || attempt === MAX_RETRY_ATTEMPTS) {
       return { ...result, attempts: attempt };

--- a/src/services/urlService.ts
+++ b/src/services/urlService.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosResponse } from "axios";
+import { setTimeout as delay } from "timers/promises";
 import {
   FAILED_REQUEST,
   HTTP_TIMEOUT,
@@ -9,9 +10,12 @@ import {
   URL_WORKING,
   URL_BROKEN,
   LOCALHOST_URLS,
+  MAX_RETRY_ATTEMPTS,
+  RETRY_DELAY_MS,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_BAD_REQUEST,
 } from "@constant";
 import { HTML_TITLE_REGEX } from "@/utils/regexUtils";
-
 export interface UrlCheckResult {
   url: string;
   isBroken: boolean;
@@ -19,6 +23,7 @@ export interface UrlCheckResult {
   error?: string;
   responseTime?: number;
   message?: string;
+  attempts?: number;
 }
 
 const isValidUrl = (url: string): boolean => {
@@ -57,30 +62,14 @@ const isSoft404 = (response: AxiosResponse): boolean => {
   );
 };
 
-export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
-  const startTime = Date.now();
-
+const performHttpCheck = async (
+  url: string,
+  startTime: number,
+): Promise<UrlCheckResult> => {
   try {
-    if (!isValidUrl(url)) {
-      return {
-        url,
-        isBroken: true,
-        error: INVALID_URL_FORMAT,
-        message: URL_BROKEN,
-      };
-    }
-
-    if (isLocalhostUrl(url)) {
-      return {
-        url,
-        isBroken: false,
-        message: LOCALHOST_URL_MESSAGE,
-      };
-    }
-
     const response: AxiosResponse = await axios.get(url, {
       timeout: HTTP_TIMEOUT,
-      validateStatus: (status) => status < 400,
+      validateStatus: (status) => status < HTTP_STATUS_BAD_REQUEST,
       maxRedirects: MAX_REDIRECTS,
       headers: {
         "User-Agent":
@@ -123,6 +112,55 @@ export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
       message: URL_BROKEN,
     };
   }
+};
+
+export const checkUrl = async (url: string): Promise<UrlCheckResult> => {
+  if (!isValidUrl(url)) {
+    return {
+      url,
+      isBroken: true,
+      error: INVALID_URL_FORMAT,
+      message: URL_BROKEN,
+      attempts: 1,
+    };
+  }
+
+  if (isLocalhostUrl(url)) {
+    return {
+      url,
+      isBroken: false,
+      message: LOCALHOST_URL_MESSAGE,
+      attempts: 1,
+    };
+  }
+
+  const startTime = Date.now();
+
+  for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+    const result = await performHttpCheck(url, startTime);
+
+    if (!result.isBroken) {
+      return { ...result, attempts: attempt };
+    }
+
+    const isNonRetryable =
+      result.statusCode &&
+      result.statusCode < HTTP_STATUS_INTERNAL_SERVER_ERROR;
+
+    if (isNonRetryable || attempt === MAX_RETRY_ATTEMPTS) {
+      return { ...result, attempts: attempt };
+    }
+
+    await delay(RETRY_DELAY_MS);
+  }
+
+  return {
+    url,
+    isBroken: true,
+    error: FAILED_REQUEST,
+    message: URL_BROKEN,
+    attempts: MAX_RETRY_ATTEMPTS,
+  };
 };
 
 export const checkMultipleUrls = async (


### PR DESCRIPTION
## What changed
- Added retry logic for temporarily unavailable links (5xx)
- Retries up to 3 times with delay between attempts
- Tracks attempt count in result

## Behavior
- 5xx errors → retry up to 3 times
- 4xx errors → no retry
- soft-404 → treated as broken without retry

## Testing
- [x] Verified manually using `httpstat.us`
- [x] Added unit tests covering retry behavior
- [x] All tests pass (`pnpm test`)

Close #39 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL checks now automatically retry transient failures (up to 3 attempts with short delays) and surface the attempt count in results.
  * Retry logic avoids reattempting permanent failures (e.g., client errors) and respects detected “soft-404” responses.

* **Tests**
  * Added test coverage for retry scenarios, attempt counting, and soft-404 handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Deadlink-Hunter/Broken-Link-Checker/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->